### PR TITLE
Fix compilation problem on nix

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,5 +1,3 @@
-module Setup (main) where
-
 import Distribution.Simple (defaultMain)
 
 main :: IO ()


### PR DESCRIPTION
```
[ guid-0.1.0 ] % nix-build -E 'with import <nixpkgs> { }; haskellPackages.callPackage ./. {}'
these derivations will be built:
  /nix/store/ivvbsh3wihd8i6casl8hvhxbvbimdkmk-guid-0.1.0.drv
building '/nix/store/ivvbsh3wihd8i6casl8hvhxbvbimdkmk-guid-0.1.0.drv'...
setupCompilerEnvironmentPhase
Build with /nix/store/blamkv8vbxc4nyzs61llligwi1bz9v4f-ghc-8.8.3.
unpacking sources
unpacking source archive /nix/store/mbscbmahvl8vmbzjvhy0fny7i2jlsmnj-guid-0.1.0
source root is guid-0.1.0
patching sources
compileBuildDriverPhase
setupCompileFlags: -package-db=/private/var/folders/b8/hhb93lms7mb097rx6lq3zq1m0000gn/T/nix-build-guid-0.1.0.drv-0/setup-package.conf.d -j8 -threaded -rtsopts
[1 of 1] Compiling Setup            ( Setup.hs, /private/var/folders/b8/hhb93lms7mb097rx6lq3zq1m0000gn/T/nix-build-guid-0.1.0.drv-0/Setup.o )

<no location info>: error:
    output was redirected with -o, but no output will be generated
because there is no Main module.

builder for '/nix/store/ivvbsh3wihd8i6casl8hvhxbvbimdkmk-guid-0.1.0.drv' failed with exit code 1
error: build of '/nix/store/ivvbsh3wihd8i6casl8hvhxbvbimdkmk-guid-0.1.0.drv' failed
```

Removing the module declaration fixes the problem.